### PR TITLE
提取戴森球路径配置到 DefaultPath.props 文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,4 @@ MigrationBackup/
 FodyWeavers.xsd
 
 GetDspData/gamedata
+DefaultPath.props

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,15 @@
+# Development Instructions
+
+To ensure the project correctly references the Dyson Sphere Program files, developers need to follow these steps:
+
+1. Locate the `DefaultPath.props.example` file in the root directory of the project.
+2. Copy and rename the `DefaultPath.props.example` file to `DefaultPath.props`.
+3. Open the `DefaultPath.props` file and manually modify the value of the `DysonSphereProgramPath` property to your local Dyson Sphere Program installation path. For example:
+
+    ```xml
+    <PropertyGroup>
+      <DysonSphereProgramPath>D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed</DysonSphereProgramPath>
+    </PropertyGroup>
+    ```
+
+After completing the above steps, the project will be able to correctly reference the Dyson Sphere Program files.

--- a/DEVELOPMENT.zh-cn.md
+++ b/DEVELOPMENT.zh-cn.md
@@ -1,0 +1,15 @@
+# 开发说明
+
+为了使项目能够正确引用 Dyson Sphere Program 的相关文件，开发者需要进行以下配置：
+
+1. 在项目根目录下找到 `DefaultPath.props.example` 文件。
+2. 将 `DefaultPath.props.example` 文件复制并重命名为 `DefaultPath.props`。
+3. 打开 `DefaultPath.props` 文件，手动修改 `DysonSphereProgramPath` 属性的值为你本地的 Dyson Sphere Program 安装路径。例如：
+
+    ```xml
+    <PropertyGroup>
+      <DysonSphereProgramPath>D:\SteamLibrary\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed</DysonSphereProgramPath>
+    </PropertyGroup>
+    ```
+
+完成以上步骤后，项目将能够正确引用 Dyson Sphere Program 的相关文件。

--- a/DefaultPath.props.example
+++ b/DefaultPath.props.example
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DysonSphereProgramPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program</DysonSphereProgramPath>
+  </PropertyGroup>
+</Project>

--- a/FractionateEverything/FractionateEverything.csproj
+++ b/FractionateEverything/FractionateEverything.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\DysonSphereProgram.Modding.UI.Builder.0.0.5\build\DysonSphereProgram.Modding.UI.Builder.props" Condition="Exists('..\packages\DysonSphereProgram.Modding.UI.Builder.0.0.5\build\DysonSphereProgram.Modding.UI.Builder.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="../DefaultPath.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -101,25 +102,25 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule">
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.UIModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/GetDspData/GetDspData.csproj
+++ b/GetDspData/GetDspData.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\DysonSphereProgram.Modding.UI.Builder.0.0.5\build\DysonSphereProgram.Modding.UI.Builder.props" Condition="Exists('..\packages\DysonSphereProgram.Modding.UI.Builder.0.0.5\build\DysonSphereProgram.Modding.UI.Builder.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="../DefaultPath.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -94,25 +95,25 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule">
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.UIModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/VerticalConstruction/VerticalConstruction.csproj
+++ b/VerticalConstruction/VerticalConstruction.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Import Project="..\packages\DysonSphereProgram.Modding.UI.Builder.0.0.5\build\DysonSphereProgram.Modding.UI.Builder.props" Condition="Exists('..\packages\DysonSphereProgram.Modding.UI.Builder.0.0.5\build\DysonSphereProgram.Modding.UI.Builder.props')" />
     <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <Import Project="../DefaultPath.props"/>
     <PropertyGroup>
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
         <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -78,10 +79,10 @@
         <Reference Include="System.Data" />
         <Reference Include="System.Xml" />
         <Reference Include="UnityEngine">
-          <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.dll</HintPath>
+          <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.CoreModule">
-          <HintPath>..\..\..\..\..\Steam\steamapps\common\Dyson Sphere Program\DSPGAME_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+          <HintPath>$(DysonSphereProgramPath)\DSPGAME_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
         </Reference>
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
- 创建 DefaultPath.props.example 文件，包含 DysonSphereProgramPath 配置示例。
- 更新 FractionateEverything.csproj 文件以导入 DefaultPath.props。
- 更新 DEVELOPMENT.md 文件，添加配置说明，指导开发者如何设置本地游戏路径。